### PR TITLE
Build the Docker image for daos_client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-certs/
+# The certification for DAOS client.
+docker/daosCA/certs/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,9 +70,10 @@ COPY ${LOCAL_CERTS_LOCATION} ${TEMP_CERTS_LOCATION}
 # This part has to match the testbed node hardware status.
 # TODO: now it is matching daosfs01, but in the future it needs to match ejfat.
 ARG	DAOS_AUTH=yes
-# Updated here. Make daosCA.crt owned by xmei:daos_daemons.
-ARG	DAOS_ADMIN_USER=xmei
-ARG	DAOS_ADMIN_GROUP=daos_daemons
+# TODO: search for better solutions here.
+# Since this is set to root:root, the daos pool has to be created with sudo.
+ARG	DAOS_ADMIN_USER=root
+ARG	DAOS_ADMIN_GROUP=root
 ARG	DAOS_AGENT_IFACE_CFG="yes"
 # "10" for EJFAT nodes and "0"/"1" for daosfs nodes.
 ARG	DAOS_AGENT_IFACE_NUMA_NODE_0="0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,103 +2,143 @@
 # https://github.com/daos-stack/daos/blob/release/2.4/utils/docker/vcluster/daos-client/el8/Dockerfile
 
 # Command to build it
-# podman/docker build -t 
+# $ podman/docker build -t <tag> [--no-cache] .
+#
+# Command to run the container:
+#   Ref: https://docs.daos.io/v2.4/QSG/docker/#running-the-daos-containers
+# $ export DAOS_IFACE_IP=<ib1 IP>
+# $ docker run --detach/-it --privileged --name=daos-client --hostname=daos-client \
+#     --add-host "daos-server:$DAOS_IFACE_IP" --add-host "daos-admin:$DAOS_IFACE_IP" \
+#     --add-host "daos-client:$DAOS_IFACE_IP" --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+#     --tmpfs=/run --network=host <docker_image>
 # 
-
 #
 # 'recipe' for building a RHEL variant docker image of a DAOS client node
 #
 # This Dockerfile accept the following input build arguments:
-# - BASE_IMAGE                      Base docker image to use (default "rockylinux")
+# - BASE_IMAGE                     	Base docker image to use (default "rockylinux/rockylinux")
 # - ROCKY_VERSION                   Rocky Version of the base docker image to use (default "8.8")
-# - DAOS_AUTH                      Enable DAOS authentication when set to "yes" (default "yes")
-# - DAOS_ADMIN_USER                Name or uid of the daos administrattor user (default "root")
-# - DAOS_ADMIN_GROUP               Name or gid of the daos administrattor group (default "root")
-# - DAOS_AGENT_IFACE_CFG           Enable manual configuration of the interface to use by the agent
-#                                  (default "yes")
-# - DAOS_AGENT_IFACE_NUMA_NODE     Numa node of the interface to use by the agent (default "10")
-# - DAOS_AGENT_IFACE_NAME          Name of the interface to use by the agent (default "eth0")
-# - DAOS_AGENT_IFACE_DOMAIN_NAME   Domain name of the interface to use by the agent (default "eth0")
-
+# - DAOS_AUTH                      	Enable DAOS authentication when set to "yes" (default "yes")
+# - DAOS_ADMIN_USER                	Name or uid of the daos administrattor user (default "root")
+# - DAOS_ADMIN_GROUP               	Name or gid of the daos administrattor group (default "root")
+# - DAOS_AGENT_IFACE_CFG           	Enable manual configuration of the interface to use by the agent (default "yes")
+# - DAOS_AGENT_IFACE_NUMA_NODE     	Numa node of the interface to use by the agent (default "0")
+# - DAOS_AGENT_IFACE_NAME          	Name of the interface to use by the agent (default "ib0")
+# - DAOS_AGENT_IFACE_DOMAIN_NAME   	Domain name of the interface to use by the agent (default "eth0")
 
 # Pull base image
-# ARG BASE_IMAGE=docker.io/library/rockylinux
 ARG BASE_IMAGE=rockylinux/rockylinux
 ARG	ROCKY_VERSION=8.8
 FROM $BASE_IMAGE:$ROCKY_VERSION as base
 LABEL maintainer="xmei@jlab.org"
 LABEL description="The docker file to set up EJFAT tesbed nodes for DAOS client."
 
-# Install the Infiniband kernels and drivers on host OS.
+## Install the Infiniband kernels and drivers on host OS.
 # sudo apt install infiniband-diags ibutils ibverbs-utils rdmacm-utils libibverbs-dev
 
-# Install Infiniband utilities & perf tools in docker image.
-RUN dnf update -y && dnf install -y infiniband-diags perftest rdma-core libibverbs
+## Install Infiniband utilities tools in docker image.
+RUN yum update -y && yum install -y rdma-core libibverbs
 
-# Install necessary tools for debugging and testing.
-RUN yum update && yum install -y wget iputils iproute net-tools 
+## Install dependencies
+# wget and ucx are must-haves. ucx is for dRPC.
+RUN yum install -y wget epel-release ucx ucx-devel
 
+# Install necessary tools for BW debugging and testing. In production mode we can remove them.
+RUN yum install -y iputils iproute net-tools perftest infiniband-diags && yum clean all
+
+## Install DAOS client package
 # Configure access to the DAOS package repository
 # In JLab network, use the EJFAT nodes to build it. Otherwise you may encounter SSL \
 # certification error on personal PCs.
-
 RUN wget -O /etc/yum.repos.d/daos-packages.repo \
 	https://packages.daos.io/v2.4/EL8/packages/x86_64/daos_packages.repo && \
-	rpm --import https://packages.daos.io/RPM-GPG-KEY && \
-	yum install -y epel-release
+	rpm --import https://packages.daos.io/RPM-GPG-KEY
 
-# Install DAOS client package
 RUN dnf install -y daos-client && \
 	dnf clean all && \
 	systemctl enable daos_agent
 
-# # Install certificates
-# # This part has to match the testbed node hardware status
-# ARG	DAOS_AUTH=yes
-# ARG	DAOS_ADMIN_USER=root
-# ARG	DAOS_ADMIN_GROUP=root
-# ARG	DAOS_AGENT_IFACE_CFG="yes"
-ARG	DAOS_AGENT_IFACE_NUMA_NODE="10"  # "10" for EJFAT nodes and "0"/"1" for DAOS nodes
-# ARG	DAOS_AGENT_IFACE_NAME="eth0"
-# ARG	DAOS_AGENT_IFACE_DOMAIN_NAME="eth0"
-# COPY	daos_agent.yml.in /tmp/daos_agent.yml.in
-# RUN	if [ "$DAOS_AUTH" == yes ] ; then                                                          \
-# 		sed --in-place --regexp-extended                                                   \
-# 			--expression '/^@DAOS_NOAUTH_SECTION_BEGIN@$/,/^@DAOS_NOAUTH_SECTION_END@/d' \
-# 			--expression '/(^@DAOS_AUTH_SECTION_BEGIN@$)|(^@DAOS_AUTH_SECTION_END@$)/d' \
-# 			/tmp/daos_agent.yml.in &&                                                  \
-# 		chmod 644 /root/daosCA/certs/daosCA.crt &&                                         \
-# 		chmod 644 /root/daosCA/certs/agent.crt &&                                          \
-# 		chmod 600 /root/daosCA/certs/agent.key &&                                          \
-# 		chown "$DAOS_ADMIN_USER:$DAOS_ADMIN_GROUP" /root/daosCA/certs/daosCA.crt &&        \
-# 		chown daos_agent:daos_agent /root/daosCA/certs/agent.crt &&                        \
-# 		chown daos_agent:daos_agent /root/daosCA/certs/agent.key &&                        \
-# 		mv /root/daosCA/certs/daosCA.crt /etc/daos/certs/. &&                              \
-# 		mv /root/daosCA/certs/agent.crt /etc/daos/certs/. &&                               \
-# 		mv /root/daosCA/certs/agent.key /etc/daos/certs/. &&                               \
-# 		rm -fr /root/daosCA ;                                                              \
-# 	else                                                                                       \
-# 		sed --in-place --regexp-extended                                                   \
-# 			--expression '/^@DAOS_AUTH_SECTION_BEGIN@$/,/^@DAOS_AUTH_SECTION_END@/d'   \
-# 			--expression '/(^@DAOS_NOAUTH_SECTION_BEGIN@$)|(^@DAOS_NOAUTH_SECTION_END@$)/d' \
-# 			/tmp/daos_agent.yml.in ;                                                   \
-# 	fi &&                                                                                      \
-# 	if [[ "${DAOS_AGENT_IFACE_CFG}" == yes ]] ; then                                           \
-# 		for it in DAOS_AGENT_IFACE_NUMA_NODE DAOS_AGENT_IFACE_NAME DAOS_AGENT_IFACE_DOMAIN_NAME ; do \
-# 			if eval "[[ -z \"\$$it\" ]]" ; then                                        \
-# 				echo "[ERROR] Docker build argument $it is not defined" ;          \
-# 				exit 1 ;                                                           \
-# 			fi ;                                                                       \
-# 		done ;                                                                             \
-# 		sed --in-place --regexp-extended                                                   \
-# 			--expression '/(^@DAOS_IFACE_SECTION_BEGIN@$)|(^@DAOS_IFACE_SECTION_END@$)/d' \
-# 			--expression "s/@DAOS_IFACE_NUMA_NODE@/${DAOS_AGENT_IFACE_NUMA_NODE}/"     \
-# 			--expression "s/@DAOS_IFACE_NAME@/${DAOS_AGENT_IFACE_NAME}/"               \
-# 			--expression "s/@DAOS_IFACE_DOMAIN_NAME@/${DAOS_AGENT_IFACE_DOMAIN_NAME}/" \
-# 			/tmp/daos_agent.yml.in ;                                                   \
-# 	else                                                                                       \
-# 		sed --in-place --regexp-extended                                                   \
-# 			--expression '/^@DAOS_IFACE_SECTION_BEGIN@$/,/^@DAOS_IFACE_SECTION_END@/d' \
-# 			/tmp/daos_agent.yml.in ;                                                   \
-# 	fi &&                                                                                      \
-# 	mv -f /tmp/daos_agent.yml.in /etc/daos/daos_agent.yml
+## Install certificates
+
+# Copy the certifications to the docker build machine first.
+# For security issues, DO NOT push the certifications to Github!!!
+# LOCAL_CERTS_LOCATION is for docker build and is error prone!
+ARG LOCAL_CERTS_LOCATION="daosCA/certs"
+ARG TEMP_CERTS_LOCATION="/root/daosCA"
+COPY ${LOCAL_CERTS_LOCATION} ${TEMP_CERTS_LOCATION}
+
+# This part has to match the testbed node hardware status.
+# TODO: now it is matching daosfs01, but in the future it needs to match ejfat.
+ARG	DAOS_AUTH=yes
+# Updated here. Make daosCA.crt owned by xmei:daos_daemons.
+ARG	DAOS_ADMIN_USER=xmei
+ARG	DAOS_ADMIN_GROUP=daos_daemons
+ARG	DAOS_AGENT_IFACE_CFG="yes"
+# "10" for EJFAT nodes and "0"/"1" for daosfs nodes.
+ARG	DAOS_AGENT_IFACE_NUMA_NODE_0="0"
+ARG	DAOS_AGENT_IFACE_NUMA_NODE_1="1"
+# "iface_name" is got from "ip -br a". For daosfs nodes, "ib1" is for NUMA_NODE "0" and "ib3" is for "1".
+ARG	DAOS_AGENT_IFACE_NAME_0="ib1"
+ARG	DAOS_AGENT_IFACE_NAME_1="ib3"
+# For daosfs nodes, "mlx5_1" is for NUMA_NODE "0" and "mlx5_3" is for "1"
+ARG	DAOS_AGENT_IFACE_DOMAIN_NAME_0="mlx5_1"
+ARG	DAOS_AGENT_IFACE_DOMAIN_NAME_1="mlx5_3"
+COPY daos_agent.yml.in /tmp/daos_agent.yml.in
+RUN	if [ "$DAOS_AUTH" == yes ] ; then                                                          \
+		sed --in-place --regexp-extended                                                   \
+			--expression '/^@DAOS_NOAUTH_SECTION_BEGIN@$/,/^@DAOS_NOAUTH_SECTION_END@/d' \
+			--expression '/(^@DAOS_AUTH_SECTION_BEGIN@$)|(^@DAOS_AUTH_SECTION_END@$)/d' \
+			/tmp/daos_agent.yml.in &&                                                  \
+		chmod 644 ${TEMP_CERTS_LOCATION}/certs/daosCA.crt &&                                         \
+		chmod 644 ${TEMP_CERTS_LOCATION}/certs/agent.crt &&                                          \
+		chmod 400 ${TEMP_CERTS_LOCATION}/certs/agent.key &&                                          \
+		chown "$DAOS_ADMIN_USER:$DAOS_ADMIN_GROUP" ${TEMP_CERTS_LOCATION}/certs/daosCA.crt &&        \
+		chown daos_agent:daos_agent ${TEMP_CERTS_LOCATION}/certs/agent.crt &&                        \
+		chown daos_agent:daos_agent ${TEMP_CERTS_LOCATION}/certs/agent.key &&                        \
+		mv ${TEMP_CERTS_LOCATION}/certs/daosCA.crt /etc/daos/certs/. &&                              \
+		mv ${TEMP_CERTS_LOCATION}/certs/agent.crt /etc/daos/certs/. &&                               \
+		mv ${TEMP_CERTS_LOCATION}/certs/agent.key /etc/daos/certs/. &&                               \
+		rm -fr ${TEMP_CERTS_LOCATION} ;                                                              \
+	else                                                                                       \
+		sed --in-place --regexp-extended                                                   \
+			--expression '/^@DAOS_AUTH_SECTION_BEGIN@$/,/^@DAOS_AUTH_SECTION_END@/d'   \
+			--expression '/(^@DAOS_NOAUTH_SECTION_BEGIN@$)|(^@DAOS_NOAUTH_SECTION_END@$)/d' \
+			/tmp/daos_agent.yml.in ;                                                   \
+	fi &&                                                                                      \
+	if [[ "${DAOS_AGENT_IFACE_CFG}" == yes ]] ; then                                           \
+		for it in DAOS_AGENT_IFACE_NUMA_NODE_0 DAOS_AGENT_IFACE_NAME_0 DAOS_AGENT_IFACE_DOMAIN_NAME_0 ; do \
+			if eval "[[ -z \"\$$it\" ]]" ; then                                        \
+				echo "[ERROR] Docker build argument $it is not defined" ;          \
+				exit 1 ;                                                           \
+			fi ;                                                                       \
+		done ;																							\
+		for it in DAOS_AGENT_IFACE_NUMA_NODE_1 DAOS_AGENT_IFACE_NAME_1 DAOS_AGENT_IFACE_DOMAIN_NAME_1 ; do \
+			if eval "[[ -z \"\$$it\" ]]" ; then                                        \
+				echo "[ERROR] Docker build argument $it is not defined" ;          \
+				exit 1 ;                                                           \
+			fi ;                                                                       \
+		done ;                                                                            \
+		sed --in-place --regexp-extended                                                   \
+			--expression '/(^@DAOS_IFACE_SECTION_BEGIN@$)|(^@DAOS_IFACE_SECTION_END@$)/d' \
+			--expression "s/@DAOS_IFACE_NUMA_NODE_0@/${DAOS_AGENT_IFACE_NUMA_NODE_0}/"     \
+			--expression "s/@DAOS_IFACE_NAME_0@/${DAOS_AGENT_IFACE_NAME_0}/"               \
+			--expression "s/@DAOS_IFACE_DOMAIN_NAME_0@/${DAOS_AGENT_IFACE_DOMAIN_NAME_0}/" \
+			--expression "s/@DAOS_IFACE_NUMA_NODE_1@/${DAOS_AGENT_IFACE_NUMA_NODE_1}/"     \
+			--expression "s/@DAOS_IFACE_NAME_1@/${DAOS_AGENT_IFACE_NAME_1}/"               \
+			--expression "s/@DAOS_IFACE_DOMAIN_NAME_1@/${DAOS_AGENT_IFACE_DOMAIN_NAME_1}/" \
+			/tmp/daos_agent.yml.in ;                                                   \
+	else                                                                                       \
+		sed --in-place --regexp-extended                                                   \
+			--expression '/^@DAOS_IFACE_SECTION_BEGIN@$/,/^@DAOS_IFACE_SECTION_END@/d' \
+			/tmp/daos_agent.yml.in ;                                                   \
+	fi &&                                                                                      \
+	mv -f /tmp/daos_agent.yml.in /etc/daos/daos_agent.yml
+
+## Setup entrypoint
+RUN mkdir -p /var/run/daos_agent && chmod 755 /var/run/daos_agent
+
+# Donot use systemctl start daos_agent. See the error below.
+# [root@daos-client /]# systemctl start daos_agent
+# System has not been booted with systemd as init system (PID 1). Can't operate.
+# Failed to connect to bus: Host is down
+CMD daos_agent

--- a/docker/daos_agent.yml.in
+++ b/docker/daos_agent.yml.in
@@ -1,0 +1,43 @@
+# Input of the DAOS agent configuration file.
+# Author: xmei@jlab.org. Init date: Feb/26 2024.
+
+# Changed based on the file at \
+# https://github.com/daos-stack/daos/blob/release/2.4/utils/docker/vcluster/daos-client/el8/daos_agent.yml.in
+
+name: daos_server
+
+# TODO: Adjust this part based on your DAOS server configuration!!!
+access_points:
+- daosfs02
+- daosfs03
+- daosfs04
+
+port: 10001
+
+runtime_dir: /var/run/daos_agent
+log_file: /tmp/daos_agent.log
+control_log_mask: DEBUG
+disable_caching: true
+
+transport_config:
+@DAOS_NOAUTH_SECTION_BEGIN@
+  allow_insecure: true
+@DAOS_NOAUTH_SECTION_END@
+@DAOS_AUTH_SECTION_BEGIN@
+  allow_insecure: false
+  ca_cert: /etc/daos/certs/daosCA.crt
+  cert: /etc/daos/certs/agent.crt
+  key: /etc/daos/certs/agent.key
+@DAOS_AUTH_SECTION_END@
+
+@DAOS_IFACE_SECTION_BEGIN@
+fabric_ifaces:
+- numa_node: @DAOS_IFACE_NUMA_NODE_0@
+  devices:
+    - iface: @DAOS_IFACE_NAME_0@
+      domain: @DAOS_IFACE_DOMAIN_NAME_0@
+- numa_node: @DAOS_IFACE_NUMA_NODE_1@
+  devices:
+    - iface: @DAOS_IFACE_NAME_1@
+      domain: @DAOS_IFACE_DOMAIN_NAME_1@
+@DAOS_IFACE_SECTION_END@

--- a/docker/daos_agent_daosfs01.yml
+++ b/docker/daos_agent_daosfs01.yml
@@ -1,0 +1,74 @@
+# This one is the daos_agent.yml in production running on the daosfs01 hostOS.
+
+name: daos_server
+
+# TODO: Adjust this part based on your DAOS server configuration!!!
+access_points:
+- daosfs02
+- daosfs03
+- daosfs04
+
+port: 10001
+
+## Transport Credentials Specifying certificates to secure communications
+#
+transport_config:
+  allow_insecure: false
+  ca_cert: /etc/daos/certs/daosCA.crt
+  cert: /etc/daos/certs/agent.crt
+  key: /etc/daos/certs/agent.key
+
+runtime_dir: /var/run/daos_agent
+
+log_file: /tmp/daos_agent.log
+
+## Force specific debug mask for daos_agent (control plane).
+## Mask specifies minimum level of message significance to pass to logger.
+## Currently supported values are DISABLED, TRACE, DEBUG, INFO, NOTICE and ERROR.
+#
+## default: INFO
+control_log_mask: TRACE
+
+## Disable automatic eviction of open pool handles on agent shutdown. By default,
+## the agent will evict all open pool handles for local processes on shutdown.
+## Note that this implies that stopping or restarting the agent will result
+## in interruption of DAOS I/O for any local DAOS client processes that have
+## an open pool handle.
+# disable_auto_evict: true
+
+## Disable the agent's internal caches. If set to true, the agent will query the
+## server access point and local hardware data every time a client requests
+## rank connection information.
+#
+## default: false
+disable_caching: true
+
+## Automatically expire the agent's remote cache after a period of time defined in
+## minutes. It will refresh the data the next time it is requested.
+#
+## default: 0 (never expires)
+#cache_expiration: 30
+
+## Ignore a subset of fabric interfaces when selecting an interface for client
+## applications.
+#
+#exclude_fabric_ifaces: ["lo", "eth1"]
+
+# Manually define the fabric interfaces and domains to be used by the agent,
+# organized by NUMA node.
+# If not defined, the agent will automatically detect all fabric interfaces and
+# select appropriate ones based on the server preferences.
+#
+fabric_ifaces:
+-
+  numa_node: 0
+  devices:
+  -
+    iface: ib1
+    domain: mlx5_1
+-
+  numa_node: 1
+  devices:
+  -
+    iface: ib3
+    domain: mlx5_3


### PR DESCRIPTION
Update the Dockerfile to support 2 IB devices on node `daosfs01`.

## Test

1. Create a pool with `sudo dmg`, since the permission in the docker container for now is set to `root:root`.
2. `docker pull` the image and run it in detach mode with
   ```bash
   podman run --detach --cap-add=ALL --privileged --name=daos-client --hostname=daos-client --add-host "daos-client:$DAOS_IFACE_IP" --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs=/run --network=host cc17b
   ```
3. `docker exec` with `daos pool autotest`
  ```bash
    [root@daosfs01 xmei]# podman exec daos-client daos pool autotest docker-pool
  Step Operation                 Status Time(sec) Comment
    0  Initializing DAOS          PASS    0.000  
    ...
   43  Reading RF2 values back   100%
  ```